### PR TITLE
Try to make the major tag the "production" one, for now.

### DIFF
--- a/biocomplexity/templates/pepita/deployment.yaml
+++ b/biocomplexity/templates/pepita/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: pepita-container
-        image: ghcr.io/nssac/pepita:0.1.3
+        image: ghcr.io/nssac/pepita:1
         ports:
         - containerPort: 8000
         # env:


### PR DESCRIPTION
I'm thinking to change the metadata action to not bump the bare major version on each minor and patch bump. I'll manually bump the bare major to the latest minor and patch, only when we want to update the deploy.